### PR TITLE
DHFPROD-8730: Support organization sort, do not support multiple entity sort

### DIFF
--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/options/search-options.xml
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/options/search-options.xml
@@ -67,6 +67,16 @@
         <search:path-index xmlns:oex="http://www.w3.org/2000/xmlns/">/person/createdOn/ts</search:path-index>
       </search:sort-order>
     </search:state>
+    <search:state name="organization_createdOn_ascending">
+      <search:sort-order type="xs:dateTime" direction="ascending">
+        <search:path-index xmlns:oex="http://www.w3.org/2000/xmlns/">/organization/createdOn/ts</search:path-index>
+      </search:sort-order>
+    </search:state>
+    <search:state name="organization_createdOn_descending">
+      <search:sort-order type="xs:dateTime" direction="descending">
+        <search:path-index xmlns:oex="http://www.w3.org/2000/xmlns/">/organization/createdOn/ts</search:path-index>
+      </search:sort-order>
+    </search:state>
   </search:operator>
   <!--
 Uncomment to return no results for a blank search, rather than the default of all results

--- a/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
+++ b/examples/entity-viewer-v2/entity-viewer-client/src/main/ml-modules/root/explore-data/ui-config/config.json
@@ -316,6 +316,7 @@
       "config": {
         "pageLengths": [3, 5, 10, 20],
         "sort":{
+          "entities": ["person", "organization"],
           "label": "Created On",
           "sortBy": "createdOn",
           "order": "descending"

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.scss
@@ -3,6 +3,7 @@
         display: flex;
         justify-content: flex-end;
         gap: 5px;
+        height: 30px;
         padding-bottom: 5px;
         border-bottom: solid 1px #ccc;
         .thumbnailClean {

--- a/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
+++ b/marklogic-data-hub-central/ui-custom/src/components/ResultsList/ResultsList.tsx
@@ -12,6 +12,7 @@ import {getValByConfig} from "../../util/util";
 import Pagination from "../Pagination/Pagination";
 import ResultActions from "../ResultActions/ResultActions";
 import {CaretDownFill, CaretUpFill} from "react-bootstrap-icons";
+import _ from "lodash";
 
 type Props = {
   config?: any;
@@ -123,13 +124,15 @@ const ResultsList: React.FC<Props> = (props) => {
       <div className="sortContainer">
         <div className="thumbnailClean"></div>
         <div className="detailClean"></div>
-        <div className="sortElements" onClick={handleSortClick}>
-          <span className="sortName">{props?.config?.sort?.label}</span>
-          <span className="sortIcons">
-            <CaretUpFill color={sortOrder === "ascending" ? "#394494" : "#ccc"} />
-            <CaretDownFill color={sortOrder === "descending" ? "#394494" : "#ccc"} />
-          </span>
-        </div>
+        {_.includes(props.config.sort.entities, searchContext.entityType) ?
+          <div className="sortElements" onClick={handleSortClick}>
+            <span className="sortName">{props?.config?.sort?.label}</span>
+            <span className="sortIcons">
+              <CaretUpFill color={sortOrder === "ascending" ? "#394494" : "#ccc"} />
+              <CaretDownFill color={sortOrder === "descending" ? "#394494" : "#ccc"} />
+            </span>
+          </div>
+        : null}
       </div>
     );
   };


### PR DESCRIPTION
Add search option to support the organization entity in the example app.
Add a sort.entities property to allow configuration of what entities are supported.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Code passes ESLint tests
- [ ] Added Tests  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki

